### PR TITLE
fix: correct format for inline tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ Run an Artillery test from a config file.
 
 Run an Artillery test from inline configuration.
 
+**Note:** Artillery 2.0+ requires using `flow` instead of `requests` in scenarios. See the example below for the correct format.
+
 **Parameters:**
 - `configText` (required): Artillery config as YAML/JSON string
 - `outputJson` (optional): Path for JSON results output
@@ -222,11 +224,29 @@ Run an Artillery test from inline configuration.
 - `validateOnly` (optional): Dry-run validation only
 
 **Example:**
-```json
-{
-  "configText": "config:\n  target: 'https://example.com'\n  phases:\n    - duration: 10\n      arrivalRate: 5",
-  "outputJson": "/path/to/results.json"
-}
+```yaml
+# Artillery 2.0 Configuration Format
+configText: |
+  config:
+    target: 'https://sighthoundnoir.co.uk'
+    phases:
+      - duration: 60
+        arrivalCount: 3
+    defaults:
+      headers:
+        User-Agent: 'Artillery-MCP-Server/1.0.0'
+  
+  scenarios:
+    - name: "Load Test"
+      flow:
+        - get:
+            url: /
+        - think: 1
+        - get:
+            url: /
+        - think: 1
+        - get:
+            url: /
 ```
 
 ### 3. `quick_test`

--- a/examples/http.yml
+++ b/examples/http.yml
@@ -11,7 +11,7 @@ config:
 
 scenarios:
   - name: "Basic HTTP test"
-    requests:
+    flow:
       - get:
           url: "/get"
       - post:


### PR DESCRIPTION
http.yml - Changed requests: to flow: in scenarios
This makes the example file compatible with Artillery 2.0+

README.md - Updated Documentation
Added note that Artillery 2.0+ requires flow instead of requests
Replaced the broken JSON example with a working Artillery 2.0 YAML example
Shows users the correct format for creating inline tests