### PR TITLE
fix: parse results not working when called by mcp server

### DIFF
--- a/src/lib/artillery.ts
+++ b/src/lib/artillery.ts
@@ -272,19 +272,21 @@ export class ArtilleryWrapper {
   private async parseSummary(jsonPath: string): Promise<ArtillerySummary> {
     const results = await this.parseResults(jsonPath);
     
-    // Extract metrics from Artillery output format
-    const metrics = results.metrics || {};
-    const http = metrics.http || {};
+    // Extract metrics from Artillery 2.0 output format
+    const aggregate = results.aggregate || {};
+    const counters = aggregate.counters || {};
+    const rates = aggregate.rates || {};
+    const summaries = aggregate.summaries || {};
     
     return {
-      requestsTotal: http.requests?.count || 0,
-      rpsAvg: http.requests?.rate || 0,
+      requestsTotal: counters['http.requests'] || 0,
+      rpsAvg: rates['http.request_rate'] || 0,
       latencyMs: {
-        p50: http.response_time?.p50 || 0,
-        p95: http.response_time?.p95 || 0,
-        p99: http.response_time?.p99 || 0
+        p50: summaries['http.response_time']?.p50 || 0,
+        p95: summaries['http.response_time']?.p95 || 0,
+        p99: summaries['http.response_time']?.p99 || 0
       },
-      errors: http.errors || {}
+      errors: counters['http.errors'] || {}
     };
   }
 

--- a/src/tools/parse-results.ts
+++ b/src/tools/parse-results.ts
@@ -30,19 +30,21 @@ export class ParseResultsTool implements MCPTool {
       // Parse the results
       const results = await this.artillery.parseResults(jsonPath);
       
-      // Extract summary
-      const metrics = results.metrics || {};
-      const http = metrics.http || {};
+      // Extract summary using Artillery 2.0 format
+      const aggregate = results.aggregate || {};
+      const counters = aggregate.counters || {};
+      const rates = aggregate.rates || {};
+      const summaries = aggregate.summaries || {};
       
       const summary = {
-        requestsTotal: http.requests?.count || 0,
-        rpsAvg: http.requests?.rate || 0,
+        requestsTotal: counters['http.requests'] || 0,
+        rpsAvg: rates['http.request_rate'] || 0,
         latencyMs: {
-          p50: http.response_time?.p50 || 0,
-          p95: http.response_time?.p95 || 0,
-          p99: http.response_time?.p99 || 0
+          p50: summaries['http.response_time']?.p50 || 0,
+          p95: summaries['http.response_time']?.p95 || 0,
+          p99: summaries['http.response_time']?.p99 || 0
         },
-        errors: http.errors || {}
+        errors: counters['http.errors'] || {}
       };
 
       // Extract scenario information


### PR DESCRIPTION
1. src/lib/artillery.ts - Fixed parseSummary method
Before: Looking for results.metrics.http (wrong path for Artillery 2.0)
After: Looking for results.aggregate.counters/rates/summaries (correct path)

2. src/tools/parse-results.ts - Fixed ParseResultsTool
Before: Using old Artillery format parsing logic
After: Updated to use Artillery 2.0 format parsing logic

Before: parse_results tool returned 0 values for all metrics
After: parse_results tool returns actual performance data:

requestsTotal: 180 (instead of 0)
rpsAvg: 72 (instead of 0)
latencyMs: { p50: 23.8, p95: 36.2, p99: 127.8 } (instead of all 0s)

This fixes a critical bug where the parse_results tool was completely broken and returning meaningless data. Now users can properly analyze their Artillery test results with accurate performance metrics.

